### PR TITLE
Parse ship gallery for skins availability

### DIFF
--- a/src/ships/ship.ts
+++ b/src/ships/ship.ts
@@ -126,16 +126,26 @@ export type Skill = {
     description: string;
     color: string;
 }
+export enum SkinLimitedStatus {
+    Unavailable = 'Unavailable',
+    EventLimited = 'Event Limited',
+    PermanentlyAvailable = 'Permanently Available',
+    Limited = 'Limited'
+};
 
-export type SkinInfo = {
+type SkinLimitedValue = `${SkinLimitedStatus}`
+export interface SkinInfo extends  Record<string, string| number| boolean> {
     enClient?: string;
     cnClient?: string;
     jpClient?: string;
+    enLimited?: SkinLimitedValue;
+    cnLimited?: SkinLimitedValue;
+    jpLimited?: SkinLimitedValue;
     cost?: number;
     obtainedFrom: string;
     live2dModel: boolean;
-};
 
+};
 export interface Skin {
     name: string;
     chibi: Url;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,3 +129,15 @@ export function timeout(ms: number): Promise<void> {
 export function textOr(node: Node, other: string) {
     return node ? node.textContent : other;
 }
+// No Shame
+// https://stackoverflow.com/a/64123628
+export function keepIfInEnum<T>(
+    value: string,
+    enumObject: { [key: string]: T }
+  ) {
+    if (Object.values(enumObject).includes((value as unknown) as T)) {
+      return (value as unknown) as T;
+    } else {
+      return undefined;
+    }
+  }


### PR DESCRIPTION
This would parse each ship's gallery page for the three `enClient`, `cnClient`, and `jpClient` table rows below *most* skins, check and verify that the availability data to the right of the skin name is something we expect, and update the skin's entry in the `ships.internal.json` with a `enLimited`, `cnLimited`, and a `jpLimited` property.

In the case of skins that are named `skin unavailable` (i.e. [One Day as a Trainee Clerk](https://azurlane.koumakan.jp/wiki/Rodney/Gallery#One_Day_as_a_Trainee_Clerk-0)), the `xClient` where it is not available is set `xLimited: 'Unavailable'`